### PR TITLE
Fix sbt console.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,12 +8,7 @@ lazy val functionalScala = (project in file(".")).
     scalaVersion  := "2.12.6",
     initialCommands in Compile in console := """
                                                |import scalaz._
-                                               |import scalaz.zio._
-                                               |import scalaz.zio.console._
                                                |import net.degoes._
-                                               |object replRTS extends RTS {}
-                                               |import replRTS._
-                                               |implicit class RunSyntax[E, A](io: IO[E, A]){ def unsafeRun: A = replRTS.unsafeRun(io) }
     """.stripMargin
   )
 


### PR DESCRIPTION
Remove some broken sbt console initialCommands. These relied on dependencies that do not actually exist in the project.

Without this change, running `./sbt console` produces the following errors:

```
<console>:13: error: object zio is not a member of package scalaz
       import scalaz.zio._
                     ^
<console>:14: error: object zio is not a member of package scalaz
       import scalaz.zio.console._
                     ^
<console>:16: error: not found: type RTS
       object replRTS extends RTS {}
                              ^
<console>:18: error: not found: type IO
       implicit class RunSyntax[E, A](io: IO[E, A]){ def unsafeRun: A = replRTS.unsafeRun(io) }
                                          ^
<console>:18: error: value unsafeRun is not a member of object replRTS
       implicit class RunSyntax[E, A](io: IO[E, A]){ def unsafeRun: A = replRTS.unsafeRun(io) }
                                                                                ^
```

Nothing in the codebase actually depends on ZIO, so I just removed those commands.