### PR TITLE
update few versions here and there, SBT, Scala, scalafmt...

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "2.0.0-RC6"
+version = "2.2.2"
 maxColumn = 120
 align = most
 continuationIndent.defnSite = 2

--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,17 @@
 import sbt._
 
-lazy val functionalScala = (project in file(".")).
-  settings (
-    name          := "Functional Scala",
-    organization  := "net.degoes",
-    version       := "0.1-SNAPSHOT",
-    scalaVersion  := "2.12.6",
-    initialCommands in Compile in console := """
-                                               |import scalaz._
-                                               |import net.degoes._
+lazy val functionalScala = (project in file(".")).settings(
+  name := "Functional Scala",
+  organization := "net.degoes",
+  version := "0.1-SNAPSHOT",
+  scalaVersion := "2.12.10",
+  initialCommands in Compile in console := """
+                                             |import scalaz._
+                                             |import net.degoes._
     """.stripMargin
-  )
+)
 
-scalaVersion := "2.12.6"
+scalaVersion := "2.12.10"
 
 addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.6")
 
@@ -29,41 +28,37 @@ scalacOptions ++= Seq(
   "-language:_"
 )
 
-javacOptions ++= Seq("-Xlint:unchecked",
-                     "-Xlint:deprecation",
-                     "-source",
-                     "1.7",
-                     "-target",
-                     "1.7")
+javacOptions ++= Seq("-Xlint:unchecked", "-Xlint:deprecation", "-source", "1.7", "-target", "1.7")
 
-val ScalaZVersion = "7.2.26"
-val Http4sVersion = "0.20.1"
-val CirceVersion = "0.12.0-M1"
-val DoobieVersion = "0.7.0-M5"
-val ZIOVersion = "1.0-RC4"
-val PureConfigVersion = "0.11.0"
-val H2Version = "1.4.199"
+val ScalaZVersion      = "7.2.26"
+val Http4sVersion      = "0.20.13"
+val CirceVersion       = "0.12.3"
+val CirceVersionExtras = "0.12.2"
+val DoobieVersion      = "0.7.0-M5"
+val ZIOVersion         = "1.0-RC4"
+val PureConfigVersion  = "0.11.0"
+val H2Version          = "1.4.199"
 
 libraryDependencies ++= Seq(
   // -- testing --
-  "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-  "org.specs2" %% "specs2-core" % "4.3.2" % "test",
+  "org.scalacheck" %% "scalacheck"  % "1.13.4" % Test,
+  "org.scalatest"  %% "scalatest"   % "3.0.8"  % Test,
+  "org.specs2"     %% "specs2-core" % "4.3.2"  % Test,
   // Scalaz
   "org.scalaz" %% "scalaz-core" % ScalaZVersion,
   // ZIO
-  "org.scalaz" %% "scalaz-zio" % ZIOVersion,
+  "org.scalaz" %% "scalaz-zio"              % ZIOVersion,
   "org.scalaz" %% "scalaz-zio-interop-cats" % ZIOVersion,
   // Http4s
   "org.http4s" %% "http4s-blaze-server" % Http4sVersion,
-  "org.http4s" %% "http4s-circe" % Http4sVersion,
-  "org.http4s" %% "http4s-dsl" % Http4sVersion,
+  "org.http4s" %% "http4s-circe"        % Http4sVersion,
+  "org.http4s" %% "http4s-dsl"          % Http4sVersion,
   // Circe
-  "io.circe" %% "circe-generic" % CirceVersion,
-  "io.circe" %% "circe-generic-extras" % CirceVersion,
+  "io.circe" %% "circe-generic"        % CirceVersion,
+  "io.circe" %% "circe-generic-extras" % CirceVersionExtras,
   // Doobie
   "org.tpolecat" %% "doobie-core" % DoobieVersion,
-  "org.tpolecat" %% "doobie-h2"     % DoobieVersion,
+  "org.tpolecat" %% "doobie-h2"   % DoobieVersion,
   // log4j
   "org.slf4j" % "slf4j-log4j12" % "1.7.26",
   //pure config
@@ -71,7 +66,7 @@ libraryDependencies ++= Seq(
   //h2
   "com.h2database" % "h2" % H2Version,
   // Ammonite
-  "com.lihaoyi" % "ammonite" % "1.1.2" % "test" cross CrossVersion.full
+  "com.lihaoyi" % "ammonite" % "1.8.2" % Test cross CrossVersion.full
 )
 
 resolvers ++= Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.3.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
 resolvers ++= Seq(
-    Classpaths.typesafeReleases,
-    Classpaths.sbtPluginReleases,
-    "jgit-repo" at "http://download.eclipse.org/jgit/maven",
-    "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"
-  )
+  Classpaths.typesafeReleases,
+  Classpaths.sbtPluginReleases,
+  "jgit-repo" at "https://download.eclipse.org/jgit/maven",
+  "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"
+)
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.6")


### PR DESCRIPTION
Sadly enough, new scalafmt reformatted `build.sbt` at first save...

But with these updates, it is possible to use JDK 13 and fresher Scala and plugins